### PR TITLE
Upgrade tomcat to 11.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring-ai.version>1.0.0-M6</spring-ai.version>
+        <tomcat.version>11.0.7</tomcat.version>
     </properties>
 
     <dependencies>
@@ -41,7 +42,7 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-openai</artifactId>
-            <version>1.0.0-M6</version>
+            <version>${spring-ai.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>


### PR DESCRIPTION
Improper Cleanup on Thrown Exception and Improper Neutralization are related to a previous version of tomcat, they have been fixed in the new version, in the moment the 11.0.7 is the most recent

## Resumo por Sourcery

Atualiza o Tomcat para a versão 11.0.7 e parametriza a versão da dependência spring-ai-openai via propriedades Maven

Correções de bugs:
- Aumenta a versão do Tomcat para 11.0.7 para incluir correções de segurança e vulnerabilidade

Melhorias:
- Usa a propriedade ${spring-ai.version} para a dependência spring-ai-openai em vez de uma versão codificada

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade Tomcat to 11.0.7 and parameterize the spring-ai-openai dependency version via Maven properties

Bug Fixes:
- Bump Tomcat version to 11.0.7 to include security and vulnerability fixes

Enhancements:
- Use the ${spring-ai.version} property for the spring-ai-openai dependency instead of a hard-coded version

</details>